### PR TITLE
fix: DiaryModelからchannelが取得出来ていない事象修正

### DIFF
--- a/model/DiaryModel.js
+++ b/model/DiaryModel.js
@@ -61,6 +61,14 @@ class DiaryModel {
         this._userId = userId;
     };
 
+    get channel() {
+        return this._channel;
+    };
+
+    set channel(channel) {
+        this._channel = channel;
+    };
+
     get slackUrl() {
         return this._slackUrl;
     };


### PR DESCRIPTION
DiaryModelにchannelのgetter/setterが記述されておらず投稿のURL取得ができていなかったのを修正